### PR TITLE
Add support of API Tokens

### DIFF
--- a/cloudflare/config.go
+++ b/cloudflare/config.go
@@ -10,15 +10,25 @@ import (
 type Config struct {
 	Email   string
 	Key     string
+	Token   string
 	Options []cloudflare.Option
 }
 
-// Client() returns a new client for accessing cloudflare.
+// Client returns a new client for accessing cloudflare.
 func (c *Config) Client() (*cloudflare.API, error) {
-	client, err := cloudflare.New(c.Key, c.Email, c.Options...)
+	var err error
+	var client *cloudflare.API
+
+	if c.Token != "" {
+		client, err = cloudflare.NewWithAPIToken(c.Token, c.Options...)
+	} else {
+		client, err = cloudflare.New(c.Key, c.Email, c.Options...)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("Error creating new Cloudflare client: %s", err)
 	}
+
 	log.Printf("[INFO] Cloudflare Client configured for user: %s", c.Email)
 	return client, nil
 }

--- a/cloudflare/provider.go
+++ b/cloudflare/provider.go
@@ -21,16 +21,23 @@ func Provider() terraform.ResourceProvider {
 		Schema: map[string]*schema.Schema{
 			"email": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CLOUDFLARE_EMAIL", nil),
 				Description: "A registered Cloudflare email address.",
 			},
 
 			"key": &schema.Schema{
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CLOUDFLARE_KEY", nil),
 				Description: "The API key for operations.",
+			},
+
+			"token": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CLOUDFLARE_TOKEN", nil),
+				Description: "The API Token for operations.",
 			},
 
 			"rps": &schema.Schema{
@@ -130,10 +137,20 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	c.Transport = logging.NewTransport("Cloudflare", c.Transport)
 	options = append(options, cloudflare.HTTPClient(c))
 
-	config := Config{
-		Email:   d.Get("email").(string),
-		Key:     d.Get("key").(string),
-		Options: options,
+	config := Config{Options: options}
+
+	if v, ok := d.GetOk("token"); ok {
+		config.Token = v.(string)
+	} else if v, ok := d.GetOk("key"); ok {
+		config.Key = v.(string)
+
+		if v, ok = d.GetOk("email"); ok {
+			config.Email = v.(string)
+		} else {
+			return nil, fmt.Errorf("email is not set correctly")
+		}
+	} else {
+		return nil, fmt.Errorf("credentials are not set correctly")
 	}
 
 	client, err := config.Client()
@@ -184,11 +201,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	providerUserAgent := fmt.Sprintf("%s terraform-provider-cloudflare/%s", tfUserAgent, pv)
 	options = append(options, cloudflare.UserAgent(strings.TrimSpace(fmt.Sprintf("%s %s", client.UserAgent, providerUserAgent))))
 
-	config = Config{
-		Email:   d.Get("email").(string),
-		Key:     d.Get("key").(string),
-		Options: options,
-	}
+	config.Options = options
 
 	client, err = config.Client()
 	if err != nil {

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -37,10 +37,13 @@ resource "cloudflare_page_rule" "www" {
 
 The following arguments are supported:
 
-* `email` - (Required) The email associated with the account. This can also be
+* `email` - (Optional) The email associated with the account. This can also be
   specified with the `CLOUDFLARE_EMAIL` shell environment variable.
-* `key` - (Required) The Cloudflare API key. This can also be specified
+* `key` - (Optional) The Cloudflare API key. This can also be specified
   with the `CLOUDFLARE_KEY` shell environment variable.
+* `token` - (Optional) The Cloudflare API Token. This can also be specified with
+  the `CLOUDFLARE_TOKEN` shell environment variable. This is an alternative to
+  `email`+`key`. If both are specified, `token` will be used over `email`+`key` fields.
 * `rps` - (Optional) RPS limit to apply when making calls to the API. Default: 4.
   This can also be specified with the `CLOUDFLARE_RPS` shell environment variable.
 * `retries` - (Optional) Maximum number of retries to perform when an API request fails. Default: 3.


### PR DESCRIPTION
The old `token` field was renamed to `key` by #417. In this pull request, we are repurposing the `token` field as the new API Tokens auth scheme.

**Changes**
- Added optional `token` as an alternative to `email+key`
- Marked `email` and `key`as optional